### PR TITLE
#9 Allow special keywords to be used as query values

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,9 @@ Each field criteria is limited to the use of the `EQUALS` operator and the `IN` 
 | Persons who have a vehicle with _'GPS'_<br/>_This will be result from a query on the `feature` field of type `Map`_      | `/search?vehicles.features.value.name=gps`                                             |
 | Persons with the birthday is _'null'_                                                                                    | `/search?birthday=null`                                                                |
 | Persons who don't have jobs                                                                                              | `/search?jobEntity=null`                                                               |
-| Persons who have a vehicle without defined feature in database                                                           | `/search?vehicles.features=null`                                                       |
+| Persons who were born at current date                                                                                    | `/search?birthday=CURRENT_DATE`                                                        |
+| Persons who were born at current time                                                                                    | `/search?birthday=CURRENT_TIME`                                                        |
+| Persons who were born at current datetime                                                                                | `/search?birthday=CURRENT_DATE_TIME`                                                   |
 
 ### Advanced Query
 You can search for entities by using the query string `query`.
@@ -489,6 +491,7 @@ The value types are the following:
 | Persons with the first name 'John'                                  | /person?query=`firstName='John'`                                         |
 | Persons with the birthday equals to the given `LocalDateTime`       | /person?query=`birthday='1981-03-12T10:36:00'`                           |
 | Persons with the hire date equals to the given `OffsetDateTime`     | /person?query=`job.hireDate='2019-09-01T09:00:00Z'`                      |
+| Persons with the birthday equals to the current `LocalDateTime`     | /person?query=`birthday='CURRENT_DATE_TIME'`                             |
 | Persons who own a car (VehicleType is an Enum)                      | /person?query=`vehicle.vehicleType='CAR'`                                |
 | Persons who are 1,74 m tall                                         | /person?query=`height=174`                                               |
 | Persons who are actively employed                                   | /person?query=`job.active=true`                                          |
@@ -500,6 +503,7 @@ The value types are the following:
 | ------------------------------------------------------------------- | ----------------------------------------------------- |
 | Persons who are not named 'John'                                    | /person?query=`firstName!='John'`                     |
 | Persons with the birthday not equals to the given `LocalDateTime`   | /person?query=`birthday!='1981-03-12T10:36:00'`       |
+| Persons with the birthday not equals to the current `LocalDateTime` | /person?query=`birthday='CURRENT_DATE_TIME'`          |
 | Persons with the hire date not equals to the given `OffsetDateTime` | /person?query=`job.hireDate!='2019-09-01T09:00:00Z'`  |
 | Persons who don't own a car (VehicleType is an Enum)                | /person?query=`vehicle.vehicleType!='CAR'`            |
 | Persons who are not 1,74 m tall                                     | /person?query=`height!=174`                           |
@@ -511,6 +515,7 @@ The value types are the following:
 | ------------------------------------------------------------------- | ----------------------------------------------------- |
 | Persons who were born before the given `LocalDateTime`              | /person?query=`birthday<'1981-03-12T10:36:00'`        |
 | Persons who are hired before the given `OffsetDateTime`             | /person?query=`job.hireDate<'2019-09-01T09:00:00Z'`   |
+| Persons who are hired before current datetime                       | /person?query=`job.hireDate<'CURRENT_DATE_TIME'`      |
 | Persons who are smaller than 1,74 m                                 | /person?query=`height<174`                            |
 
 1. <a name="less-than-or-equals-operator"></a> Less than or equals operator `<=`
@@ -519,6 +524,7 @@ The value types are the following:
 | ------------------------------------------------------------------- | ----------------------------------------------------- |
 | Persons who were born before or on the given `LocalDateTime`        | /person?query=`birthday<='1981-03-12T10:36:00'`       |
 | Persons who are hired before or on the given `OffsetDateTime`       | /person?query=`job.hireDate<='2019-09-01T09:00:00Z'`  |
+| Persons who are hired before or on current datetime                 | /person?query=`job.hireDate<='CURRENT_DATE_TIME'`     |
 | Persons who are smaller than or equal to 1,74 m                     | /person?query=`height<=174`                           |
 
 1. <a name="greater-than-operator"></a> Greater than operator `>`
@@ -527,6 +533,7 @@ The value types are the following:
 | ------------------------------------------------------------------- | ----------------------------------------------------- |
 | Persons who were born after the given `LocalDateTime`               | /person?query=`birthday>'1981-03-12T10:36:00'`        |
 | Persons who are hired after the given `OffsetDateTime`              | /person?query=`job.hireDate>'2019-09-01T09:00:00Z'`   |
+| Persons who are hired after the current datetime                    | /person?query=`job.hireDate>'CURRENT_DATE_TIME'`      |
 | Persons who are taller than 1,74 m                                  | /person?query=`height>174`                            |
 
 1. <a name="greater-than-or-equals-operator"></a> Greater than or equals operator `>=`
@@ -535,6 +542,7 @@ The value types are the following:
 | ------------------------------------------------------------------- | ----------------------------------------------------- |
 | Persons who were born after or on the given `LocalDateTime`         | /person?query=`birthday>='1981-03-12T10:36:00'`       |
 | Persons who are hired after or on the given `OffsetDateTime`        | /person?query=`job.hireDate>='2019-09-01T09:00:00Z'`  |
+| Persons who are hired after or on current datetime                  | /person?query=`job.hireDate>='CURRENT_DATE_TIME'`     |
 | Persons who are taller than or equal to 1,74 m                      | /person?query=`height>=174`                           |
 
 1. <a name="matches-operator"></a> Matches operator `MATCHES`
@@ -569,6 +577,17 @@ _Use the wildcard character `*` to match any string with zero or more characters
 | Persons with the height is one the given values                         | /person?query=`height IN (168, 174, 185)`                            |
 | Persons who own one of the given vehicle types (VehicleType is an Enum) | /person?query=`vehicle.vehicleType IN ('CAR', 'MOTORBIKE', 'TRUCK')` |
 | Persons who are not named 'John' or 'Jane'                              | /person?query=`firstName NOT IN ('John', 'Jane')`                    |
+
+1. <a name="current_date_time-comparison"></a> `CURRENT_DATE_TIME` comparison
+
+| What you want to query                                  | Example                                                                 |
+| ------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Persons with the birthday is at current time            | /person?query=`birthday=CURRENT_DATE_TIME`<br/>/person?query=`birthday IS CURRENT_DATE_TIME`      |
+| Persons with the birthday is not at current time        | /person?query=`birthday!=CURRENT_DATE_TIME`<br/>/person?query=`birthday IS NOT CURRENT_DATE_TIME` |
+| Persons with the birthday is after current time         | /person?query=`birthday>CURRENT_DATE_TIME`<br/>/person?query=`birthday >= CURRENT_DATE_TIME`      |
+| Persons with the birthday is after or at current time   | /person?query=`birthday>=CURRENT_DATE_TIME`<br/>/person?query=`birthday >= CURRENT_DATE_TIME`     |
+| Persons with the birthday is before current time        | /person?query=`birthday<CURRENT_DATE_TIME`<br/>/person?query=`birthday < CURRENT_DATE_TIME`       |
+| Persons with the birthday is before or at current time  | /person?query=`birthday<=CURRENT_DATE_TIME`<br/>/person?query=`birthday <= CURRENT_DATE_TIME`     |
 
 1. <a name="null-comparison"></a> `NULL` comparison
 

--- a/core/src/main/kotlin/com/weedow/spring/data/search/expression/ExpressionResolverImpl.kt
+++ b/core/src/main/kotlin/com/weedow/spring/data/search/expression/ExpressionResolverImpl.kt
@@ -2,7 +2,11 @@ package com.weedow.spring.data.search.expression
 
 import com.weedow.spring.data.search.fieldpath.FieldPathInfo
 import com.weedow.spring.data.search.fieldpath.FieldPathResolver
+import com.weedow.spring.data.search.utils.Keyword.CURRENT_DATE
+import com.weedow.spring.data.search.utils.Keyword.CURRENT_DATE_TIME
+import com.weedow.spring.data.search.utils.Keyword.CURRENT_TIME
 import com.weedow.spring.data.search.utils.NullValue
+import com.weedow.spring.data.search.utils.NullValue.NULL_VALUE
 import org.springframework.core.convert.ConversionService
 import java.util.stream.Collectors
 
@@ -44,7 +48,15 @@ class ExpressionResolverImpl(
     }
 
     private fun convert(value: String, clazz: Class<*>): Any {
-        return if (!NullValue.NULL_VALUE.equals(value, ignoreCase = true)) conversionService.convert(value, clazz)!! else NullValue
+        return when {
+            CURRENT_DATE.equalsIgnoringCase(value) -> CURRENT_DATE
+            CURRENT_TIME.equalsIgnoringCase(value) -> CURRENT_TIME
+            CURRENT_DATE_TIME.equalsIgnoringCase(value) -> CURRENT_DATE_TIME
+            NULL_VALUE.equalsIgnoringCase(value) -> NullValue
+            else -> conversionService.convert(value, clazz)!!
+        }
     }
+
+    private fun String.equalsIgnoringCase(value: String): Boolean = this.equals(value, ignoreCase = true)
 
 }

--- a/core/src/main/kotlin/com/weedow/spring/data/search/utils/Keyword.kt
+++ b/core/src/main/kotlin/com/weedow/spring/data/search/utils/Keyword.kt
@@ -1,0 +1,21 @@
+package com.weedow.spring.data.search.utils
+
+import java.io.Serializable
+
+object Keyword : Serializable {
+
+    /** Constant representing the 'CURRENT_DATE' value. */
+    const val CURRENT_DATE = "CURRENT_DATE"
+
+    /** Constant representing the 'CURRENT_TIME' value. */
+    const val CURRENT_TIME = "CURRENT_TIME"
+
+    /** Constant representing the 'CURRENT_DATE_TIME' value. */
+    const val CURRENT_DATE_TIME = "CURRENT_DATE_TIME"
+
+    /** @suppress */
+    override fun toString(): String {
+        return javaClass.simpleName
+    }
+
+}

--- a/core/src/test/kotlin/com/weedow/spring/data/search/expression/ExpressionResolverImplTest.kt
+++ b/core/src/test/kotlin/com/weedow/spring/data/search/expression/ExpressionResolverImplTest.kt
@@ -70,6 +70,23 @@ internal class ExpressionResolverImplTest {
         assertThat(expression).isEqualTo(SimpleExpression(operator, fieldInfo, fieldValue))
     }
 
+    @ParameterizedTest
+    @MethodSource("single_date_value_with_operator_parameters")
+    fun resolve_expression_with_single_date_value(field: String, fieldValue: String, operator: Operator) {
+        val rootClass = Person::class.java
+        val fieldPath = field
+        val fieldName = field
+        val fieldClass = String::class.java
+
+        whenever(fieldPathResolver.resolveFieldPath(rootClass, fieldPath))
+                .thenReturn(FieldPathInfo(fieldPath, fieldName, fieldClass, rootClass))
+
+        val expression = expressionResolver.resolveExpression(rootClass, fieldPath, listOf(fieldValue), operator, false)
+
+        val fieldInfo = FieldInfo(fieldPath, fieldName, rootClass)
+        assertThat(expression).isEqualTo(SimpleExpression(operator, fieldInfo, fieldValue))
+    }
+
     @Test
     fun resolve_expression_with_multiple_values_and_in_operator() {
         val rootClass = Person::class.java
@@ -134,6 +151,24 @@ internal class ExpressionResolverImplTest {
         assertThat(expression).isEqualTo(NotExpression(SimpleExpression(operator, fieldInfo, fieldValue)))
     }
 
+    @ParameterizedTest
+    @MethodSource("single_date_value_with_operator_parameters")
+    fun resolve_expression_with_single_date_value_and_negative_operator(field: String, fieldValue: String, operator: Operator) {
+        val rootClass = Person::class.java
+        val fieldPath = field
+        val fieldName = field
+        val fieldClass = String::class.java
+        val negated = true
+
+        whenever(fieldPathResolver.resolveFieldPath(rootClass, fieldPath))
+                .thenReturn(FieldPathInfo(fieldPath, fieldName, fieldClass, rootClass))
+
+        val expression = expressionResolver.resolveExpression(rootClass, fieldPath, listOf(fieldValue), operator, negated)
+
+        val fieldInfo = FieldInfo(fieldPath, fieldName, rootClass)
+        assertThat(expression).isEqualTo(NotExpression(SimpleExpression(operator, fieldInfo, fieldValue)))
+    }
+
     @Test
     fun resolve_expression_with_multiple_values_and_not_in_operator() {
         val rootClass = Person::class.java
@@ -170,6 +205,28 @@ internal class ExpressionResolverImplTest {
                     Arguments.of("height", "174", Operator.LESS_THAN_OR_EQUALS),
                     Arguments.of("height", "180", Operator.GREATER_THAN),
                     Arguments.of("height", "180", Operator.GREATER_THAN_OR_EQUALS)
+            )
+        }
+
+        @JvmStatic
+        @Suppress("unused")
+        private fun single_date_value_with_operator_parameters(): Stream<Arguments> {
+            return Stream.of(
+                    Arguments.of("birthday", "CURRENT_DATE", Operator.EQUALS),
+                    Arguments.of("birthday", "CURRENT_DATE", Operator.LESS_THAN),
+                    Arguments.of("birthday", "CURRENT_DATE", Operator.LESS_THAN_OR_EQUALS),
+                    Arguments.of("birthday", "CURRENT_DATE", Operator.GREATER_THAN),
+                    Arguments.of("birthday", "CURRENT_DATE", Operator.GREATER_THAN_OR_EQUALS),
+                    Arguments.of("birthday", "CURRENT_TIME", Operator.EQUALS),
+                    Arguments.of("birthday", "CURRENT_TIME", Operator.LESS_THAN),
+                    Arguments.of("birthday", "CURRENT_TIME", Operator.LESS_THAN_OR_EQUALS),
+                    Arguments.of("birthday", "CURRENT_TIME", Operator.GREATER_THAN),
+                    Arguments.of("birthday", "CURRENT_TIME", Operator.GREATER_THAN_OR_EQUALS),
+                    Arguments.of("birthday", "CURRENT_DATE_TIME", Operator.EQUALS),
+                    Arguments.of("birthday", "CURRENT_DATE_TIME", Operator.LESS_THAN),
+                    Arguments.of("birthday", "CURRENT_DATE_TIME", Operator.LESS_THAN_OR_EQUALS),
+                    Arguments.of("birthday", "CURRENT_DATE_TIME", Operator.GREATER_THAN),
+                    Arguments.of("birthday", "CURRENT_DATE_TIME", Operator.GREATER_THAN_OR_EQUALS)
             )
         }
     }

--- a/core/src/test/kotlin/com/weedow/spring/data/search/expression/SimpleExpressionTest.kt
+++ b/core/src/test/kotlin/com/weedow/spring/data/search/expression/SimpleExpressionTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.weedow.spring.data.search.common.model.Person
 import com.weedow.spring.data.search.join.EntityJoins
+import com.weedow.spring.data.search.utils.Keyword.CURRENT_DATE
 import com.weedow.spring.data.search.utils.MAP_KEY
 import com.weedow.spring.data.search.utils.MAP_VALUE
 import com.weedow.spring.data.search.utils.NullValue
@@ -17,6 +18,7 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.junit.jupiter.MockitoExtension
+import java.sql.Date
 import javax.persistence.criteria.*
 import javax.persistence.criteria.Expression
 
@@ -38,7 +40,9 @@ internal class SimpleExpressionTest {
         whenever(entityJoins.getPath(fieldInfo.fieldPath, root)).thenReturn(path)
 
         val predicate = mock<Predicate>()
-        whenever(criteriaBuilder.equal(path, fieldValue)).thenReturn(predicate)
+        val literalExpression = mock<Expression<String>>()
+        whenever(criteriaBuilder.literal(fieldValue)).thenReturn(literalExpression)
+        whenever(criteriaBuilder.equal(path, literalExpression)).thenReturn(predicate)
 
         val expression = SimpleExpression(Operator.EQUALS, fieldInfo, fieldValue)
         val specification = expression.toSpecification<Person>(entityJoins)
@@ -272,7 +276,9 @@ internal class SimpleExpressionTest {
         whenever(entityJoins.getPath(fieldInfo.fieldPath, root)).thenReturn(path)
 
         val predicate = mock<Predicate>()
-        whenever(criteriaBuilder.lessThan(path, fieldValue)).thenReturn(predicate)
+        val literalExpression = mock<Expression<Double>>()
+        whenever(criteriaBuilder.literal(fieldValue)).thenReturn(literalExpression)
+        whenever(criteriaBuilder.lessThan(path, literalExpression)).thenReturn(predicate)
 
         val expression = SimpleExpression(Operator.LESS_THAN, fieldInfo, fieldValue)
         val specification = expression.toSpecification<Person>(entityJoins)
@@ -297,7 +303,9 @@ internal class SimpleExpressionTest {
         whenever(entityJoins.getPath(fieldInfo.fieldPath, root)).thenReturn(path)
 
         val predicate = mock<Predicate>()
-        whenever(criteriaBuilder.lessThanOrEqualTo(path, fieldValue)).thenReturn(predicate)
+        val literalExpression = mock<Expression<Double>>()
+        whenever(criteriaBuilder.literal(fieldValue)).thenReturn(literalExpression)
+        whenever(criteriaBuilder.lessThanOrEqualTo(path, literalExpression)).thenReturn(predicate)
 
         val expression = SimpleExpression(Operator.LESS_THAN_OR_EQUALS, fieldInfo, fieldValue)
         val specification = expression.toSpecification<Person>(entityJoins)
@@ -322,7 +330,9 @@ internal class SimpleExpressionTest {
         whenever(entityJoins.getPath(fieldInfo.fieldPath, root)).thenReturn(path)
 
         val predicate = mock<Predicate>()
-        whenever(criteriaBuilder.greaterThan(path, fieldValue)).thenReturn(predicate)
+        val literalExpression = mock<Expression<Double>>()
+        whenever(criteriaBuilder.literal(fieldValue)).thenReturn(literalExpression)
+        whenever(criteriaBuilder.greaterThan(path, literalExpression)).thenReturn(predicate)
 
         val expression = SimpleExpression(Operator.GREATER_THAN, fieldInfo, fieldValue)
         val specification = expression.toSpecification<Person>(entityJoins)
@@ -347,7 +357,9 @@ internal class SimpleExpressionTest {
         whenever(entityJoins.getPath(fieldInfo.fieldPath, root)).thenReturn(path)
 
         val predicate = mock<Predicate>()
-        whenever(criteriaBuilder.greaterThanOrEqualTo(path, fieldValue)).thenReturn(predicate)
+        val literalExpression = mock<Expression<Double>>()
+        whenever(criteriaBuilder.literal(fieldValue)).thenReturn(literalExpression)
+        whenever(criteriaBuilder.greaterThanOrEqualTo(path, literalExpression)).thenReturn(predicate)
 
         val expression = SimpleExpression(Operator.GREATER_THAN_OR_EQUALS, fieldInfo, fieldValue)
         val specification = expression.toSpecification<Person>(entityJoins)
@@ -391,6 +403,33 @@ internal class SimpleExpressionTest {
     fun to_field_expressions(operator: Operator) {
         assertToFieldExpressions(false, operator)
         assertToFieldExpressions(true, operator)
+    }
+
+    @Test
+    fun to_specification_with_equals_operator_and_current_date_value() {
+        val fieldPath = "birthday"
+        val fieldValue = CURRENT_DATE
+        val fieldInfo = FieldInfo(fieldPath, "firstName", Person::class.java)
+
+        val entityJoins = mock<EntityJoins>()
+
+        val root = mock<Root<Person>>()
+        val criteriaBuilder = mock<CriteriaBuilder>()
+
+        val path = mock<Path<*>>()
+        whenever(entityJoins.getPath(fieldInfo.fieldPath, root)).thenReturn(path)
+
+        val predicate = mock<Predicate>()
+        val dateExpression = mock<Expression<Date>>()
+        whenever(criteriaBuilder.currentDate()).thenReturn(dateExpression)
+        whenever(criteriaBuilder.equal(path, dateExpression)).thenReturn(predicate)
+
+        val expression = SimpleExpression(Operator.EQUALS, fieldInfo, fieldValue)
+        val specification = expression.toSpecification<Person>(entityJoins)
+
+        val result = specification.toPredicate(root, mock(), criteriaBuilder)
+
+        assertThat(result).isEqualTo(predicate)
     }
 
     private fun assertToFieldExpressions(negated: Boolean, operator: Operator) {


### PR DESCRIPTION
- Create Keyword enum holding new date constants (Null value is still kept separated so this PR is not spammed with lots of changes)
- Add keywords conversion logic to ExpressionResolver level
- Update README file

#9